### PR TITLE
Added structured group naming with metadata

### DIFF
--- a/backend/open_webui/models/groups.py
+++ b/backend/open_webui/models/groups.py
@@ -84,6 +84,7 @@ class GroupForm(BaseModel):
     name: str
     description: str
     permissions: Optional[dict] = None
+    meta: Optional[dict] = None
 
 
 class GroupUpdateForm(GroupForm):

--- a/backend/open_webui/test/apps/webui/routers/test_groups.py
+++ b/backend/open_webui/test/apps/webui/routers/test_groups.py
@@ -174,6 +174,59 @@ class TestGroups(AbstractPostgresTest):
         assert group["description"] == "updated"
         assert group["permissions"] == permissions
 
+    def test_create_stores_structured_naming_meta(self):
+        meta = {
+            "naming": {
+                "category": "Instruction",
+                "school": "School of Professional Studies (SPS)",
+                "department": "Math",
+                "tool_type": "AI Tutor",
+                "tool_name": "Calculus AI Tutor",
+                "owner": "John Smith",
+                "custom": True,
+            }
+        }
+        response = self._create(name=unique_group_name(), meta=meta)
+        assert response.status_code == 200, response.text
+        group = response.json()
+        assert group["meta"] == meta
+
+        with as_user(self.app, id="admin", role="admin", email="admin@test.com"):
+            fetched = self.fast_api_client.get(self.create_url(f"/id/{group['id']}"))
+        assert fetched.status_code == 200
+        assert fetched.json()["meta"] == meta
+
+    def test_update_without_meta_preserves_stored_meta(self):
+        meta = {"naming": {"category": "Research", "school": "NYU IT"}}
+        group = self._create(name=unique_group_name(), meta=meta).json()
+        with as_user(self.app, id="admin", role="admin", email="admin@test.com"):
+            response = self.fast_api_client.post(
+                self.create_url(f"/id/{group['id']}/update"),
+                json={"name": group["name"], "description": "updated"},
+            )
+        assert response.status_code == 200, response.text
+        assert response.json()["meta"] == meta
+
+    def test_update_replaces_meta_when_sent(self):
+        group = self._create(
+            name=unique_group_name(),
+            meta={"naming": {"category": "Research", "school": "NYU IT"}},
+        ).json()
+        updated_meta = {
+            "naming": {"category": "Administration", "school": "School of Law"}
+        }
+        with as_user(self.app, id="admin", role="admin", email="admin@test.com"):
+            response = self.fast_api_client.post(
+                self.create_url(f"/id/{group['id']}/update"),
+                json={
+                    "name": group["name"],
+                    "description": "desc",
+                    "meta": updated_meta,
+                },
+            )
+        assert response.status_code == 200, response.text
+        assert response.json()["meta"] == updated_meta
+
     def test_update_membership_with_valid_user(self):
         group = self._create().json()
         with as_user(self.app, id="admin", role="admin", email="admin@test.com"):

--- a/src/app.css
+++ b/src/app.css
@@ -387,12 +387,12 @@ input[type='number'] {
 /* Toast notification positioning fix */
 [data-sonner-toaster] {
 	position: fixed !important;
-	z-index: 9999 !important;
+	z-index: 999999999 !important;
 	top: 0 !important;
 	right: 0 !important;
 	margin: 1rem !important;
 }
 
 [data-sonner-toast] {
-	z-index: 9999 !important;
+	z-index: 999999999 !important;
 }

--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -160,7 +160,7 @@
 			{$i18n.t('Groups')}
 			<div class="flex self-center w-[1px] h-6 mx-2.5 bg-gray-50 dark:bg-gray-850" />
 
-			<span class="text-lg font-medium text-gray-500 dark:text-gray-300">
+			<span class="text-lg font-medium text-gray-600 dark:text-gray-300">
 				{#if filteredGroups.length !== groups.length}
 					{filteredGroups.length} / {groups.length}
 				{:else}
@@ -213,9 +213,9 @@
 	{#if hasNamingMetadata}
 		<div class="mb-2 flex flex-wrap items-center gap-1.5 px-0.5 text-xs">
 			<select
-				class="max-w-40 pr-6 py-0.5 rounded-lg text-xs bg-gray-50 dark:bg-gray-850 outline-hidden {categoryFilter ===
+				class="max-w-40 pl-2 pr-6 py-0.5 rounded-lg text-xs bg-gray-50 dark:bg-gray-850 outline-hidden {categoryFilter ===
 				''
-					? 'text-gray-500 dark:text-gray-400'
+					? 'text-gray-600 dark:text-gray-400'
 					: ''}"
 				bind:value={categoryFilter}
 				aria-label={$i18n.t('Filter by category')}
@@ -227,9 +227,9 @@
 			</select>
 
 			<select
-				class="max-w-48 pr-6 py-0.5 rounded-lg text-xs bg-gray-50 dark:bg-gray-850 outline-hidden {schoolFilter ===
+				class="max-w-48 pl-2 pr-6 py-0.5 rounded-lg text-xs bg-gray-50 dark:bg-gray-850 outline-hidden {schoolFilter ===
 				''
-					? 'text-gray-500 dark:text-gray-400'
+					? 'text-gray-600 dark:text-gray-400'
 					: ''}"
 				bind:value={schoolFilter}
 				aria-label={$i18n.t('Filter by school')}
@@ -241,9 +241,9 @@
 			</select>
 
 			<select
-				class="max-w-40 pr-6 py-0.5 rounded-lg text-xs bg-gray-50 dark:bg-gray-850 outline-hidden {toolFilter ===
+				class="max-w-40 pl-2 pr-6 py-0.5 rounded-lg text-xs bg-gray-50 dark:bg-gray-850 outline-hidden {toolFilter ===
 				''
-					? 'text-gray-500 dark:text-gray-400'
+					? 'text-gray-600 dark:text-gray-400'
 					: ''}"
 				bind:value={toolFilter}
 				aria-label={$i18n.t('Filter by tool')}
@@ -255,9 +255,9 @@
 			</select>
 
 			<select
-				class="max-w-40 pr-6 py-0.5 rounded-lg text-xs bg-gray-50 dark:bg-gray-850 outline-hidden {ownerFilter ===
+				class="max-w-40 pl-2 pr-6 py-0.5 rounded-lg text-xs bg-gray-50 dark:bg-gray-850 outline-hidden {ownerFilter ===
 				''
-					? 'text-gray-500 dark:text-gray-400'
+					? 'text-gray-600 dark:text-gray-400'
 					: ''}"
 				bind:value={ownerFilter}
 				aria-label={$i18n.t('Filter by owner')}
@@ -270,7 +270,7 @@
 
 			{#if categoryFilter !== '' || schoolFilter !== '' || toolFilter !== '' || ownerFilter !== ''}
 				<button
-					class="px-2 py-0.5 rounded-lg text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-850 transition"
+					class="px-2 py-0.5 rounded-lg text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-850 transition"
 					on:click={() => {
 						categoryFilter = '';
 						schoolFilter = '';
@@ -309,15 +309,15 @@
 			</div>
 		{:else}
 			<div>
-				<div class=" flex items-center gap-3 justify-between text-xs uppercase px-1 font-bold">
-					<div class="w-288">Group</div>
+				<div class=" flex items-center gap-3 text-xs uppercase px-1 font-bold">
+					<div class="flex-1 min-w-0">Group</div>
 
-					<div class="w-76">Users</div>
+					<div class="w-16 shrink-0">Users</div>
 
-					<div class="w-136">Last Active</div>
+					<div class="w-24 shrink-0">Last Active</div>
 
-					<div class="w-136">Created At</div>
-					<div class="w-full">Actions</div>
+					<div class="w-24 shrink-0">Created At</div>
+					<div class="w-[320px] shrink-0 text-right">Actions</div>
 				</div>
 
 				<hr class="mt-1.5 border-gray-100 dark:border-gray-850" />

--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -24,6 +24,7 @@
 	import AddGroupModal from './Groups/AddGroupModal.svelte';
 	import { createNewGroup, getGroups } from '$lib/apis/groups';
 	import { getUserDefaultPermissions, updateUserDefaultPermissions } from '$lib/apis/users';
+	import { groupSearchText } from './Groups/naming';
 
 	const i18n = getContext('i18n');
 
@@ -34,17 +35,57 @@
 	let groups = [];
 	let filteredGroups;
 
-	$: filteredGroups = groups.filter((user) => {
-		if (search === '') {
-			return true;
-		} else {
-			let name = user.name.toLowerCase();
-			const query = search.toLowerCase();
-			return name.includes(query);
-		}
+	let search = '';
+	let categoryFilter = '';
+	let schoolFilter = '';
+	let toolFilter = '';
+	let ownerFilter = '';
+
+	const distinctNamingValues = (groups, key) =>
+		[...new Set(groups.map((group) => group?.meta?.naming?.[key]).filter(Boolean))].sort();
+
+	$: categoryOptions = distinctNamingValues(groups, 'category');
+	$: schoolOptions = distinctNamingValues(groups, 'school');
+	$: toolOptions = [
+		...new Set(
+			groups
+				.map((group) => {
+					const naming = group?.meta?.naming;
+					return naming?.tool_name || naming?.tool_type;
+				})
+				.filter(Boolean)
+		)
+	].sort();
+	$: ownerOptions = distinctNamingValues(groups, 'owner');
+
+	$: hasNamingMetadata = groups.some((group) => {
+		const naming = group?.meta?.naming ?? {};
+		return (
+			naming.category || naming.school || naming.tool_type || naming.tool_name || naming.owner
+		);
 	});
 
-	let search = '';
+	$: filteredGroups = groups.filter((group) => {
+		if (search !== '' && !groupSearchText(group).includes(search.toLowerCase())) {
+			return false;
+		}
+
+		const naming = group?.meta?.naming ?? {};
+		if (categoryFilter !== '' && naming.category !== categoryFilter) {
+			return false;
+		}
+		if (schoolFilter !== '' && naming.school !== schoolFilter) {
+			return false;
+		}
+		if (toolFilter !== '' && (naming.tool_name || naming.tool_type) !== toolFilter) {
+			return false;
+		}
+		if (ownerFilter !== '' && naming.owner !== ownerFilter) {
+			return false;
+		}
+
+		return true;
+	});
 	let defaultPermissions = {
 		workspace: {
 			models: false,
@@ -113,13 +154,19 @@
 </script>
 
 {#if loaded}
-	<AddGroupModal bind:show={showCreateGroupModal} onSubmit={addGroupHandler} />
+	<AddGroupModal bind:show={showCreateGroupModal} onSubmit={addGroupHandler} existingGroups={groups} />
 	<div class="mt-0.5 mb-2 gap-1 flex flex-col md:flex-row justify-between">
 		<div class="flex md:self-center text-lg font-medium px-0.5">
 			{$i18n.t('Groups')}
 			<div class="flex self-center w-[1px] h-6 mx-2.5 bg-gray-50 dark:bg-gray-850" />
 
-			<span class="text-lg font-medium text-gray-500 dark:text-gray-300">{groups.length}</span>
+			<span class="text-lg font-medium text-gray-500 dark:text-gray-300">
+				{#if filteredGroups.length !== groups.length}
+					{filteredGroups.length} / {groups.length}
+				{:else}
+					{groups.length}
+				{/if}
+			</span>
 		</div>
 
 		<div class="flex gap-1">
@@ -162,6 +209,80 @@
 			</div>
 		</div>
 	</div>
+
+	{#if hasNamingMetadata}
+		<div class="mb-2 flex flex-wrap items-center gap-1.5 px-0.5 text-xs">
+			<select
+				class="max-w-40 pr-6 py-0.5 rounded-lg text-xs bg-gray-50 dark:bg-gray-850 outline-hidden {categoryFilter ===
+				''
+					? 'text-gray-500 dark:text-gray-400'
+					: ''}"
+				bind:value={categoryFilter}
+				aria-label={$i18n.t('Filter by category')}
+			>
+				<option value="">{$i18n.t('All categories')}</option>
+				{#each categoryOptions as option}
+					<option value={option}>{option}</option>
+				{/each}
+			</select>
+
+			<select
+				class="max-w-48 pr-6 py-0.5 rounded-lg text-xs bg-gray-50 dark:bg-gray-850 outline-hidden {schoolFilter ===
+				''
+					? 'text-gray-500 dark:text-gray-400'
+					: ''}"
+				bind:value={schoolFilter}
+				aria-label={$i18n.t('Filter by school')}
+			>
+				<option value="">{$i18n.t('All schools')}</option>
+				{#each schoolOptions as option}
+					<option value={option}>{option}</option>
+				{/each}
+			</select>
+
+			<select
+				class="max-w-40 pr-6 py-0.5 rounded-lg text-xs bg-gray-50 dark:bg-gray-850 outline-hidden {toolFilter ===
+				''
+					? 'text-gray-500 dark:text-gray-400'
+					: ''}"
+				bind:value={toolFilter}
+				aria-label={$i18n.t('Filter by tool')}
+			>
+				<option value="">{$i18n.t('All tools')}</option>
+				{#each toolOptions as option}
+					<option value={option}>{option}</option>
+				{/each}
+			</select>
+
+			<select
+				class="max-w-40 pr-6 py-0.5 rounded-lg text-xs bg-gray-50 dark:bg-gray-850 outline-hidden {ownerFilter ===
+				''
+					? 'text-gray-500 dark:text-gray-400'
+					: ''}"
+				bind:value={ownerFilter}
+				aria-label={$i18n.t('Filter by owner')}
+			>
+				<option value="">{$i18n.t('All owners')}</option>
+				{#each ownerOptions as option}
+					<option value={option}>{option}</option>
+				{/each}
+			</select>
+
+			{#if categoryFilter !== '' || schoolFilter !== '' || toolFilter !== '' || ownerFilter !== ''}
+				<button
+					class="px-2 py-0.5 rounded-lg text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-850 transition"
+					on:click={() => {
+						categoryFilter = '';
+						schoolFilter = '';
+						toolFilter = '';
+						ownerFilter = '';
+					}}
+				>
+					{$i18n.t('Clear filters')}
+				</button>
+			{/if}
+		</div>
+	{/if}
 
 	<div>
 		{#if filteredGroups.length === 0}

--- a/src/lib/components/admin/Users/Groups/AddGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/AddGroupModal.svelte
@@ -1,25 +1,108 @@
 <script lang="ts">
 	import { toast } from 'svelte-sonner';
-	import { getContext, onMount } from 'svelte';
+	import { getContext } from 'svelte';
 	const i18n = getContext('i18n');
+
+	import { user } from '$lib/stores';
 
 	import Modal from '$lib/components/common/Modal.svelte';
 	import Textarea from '$lib/components/common/Textarea.svelte';
+	import {
+		CATEGORY_OPTIONS,
+		SCHOOL_OPTIONS,
+		TOOL_TYPE_OPTIONS,
+		generateGroupName
+	} from './naming';
+
 	export let onSubmit: Function = () => {};
 	export let show = false;
+	export let existingGroups: { name?: string }[] = [];
 
-	let name = '';
+	const OTHER_SCHOOL = '__other__';
+
+	let category = '';
+	let school = '';
+	let customSchool = '';
+	let department = '';
+	let toolType = '';
+	let toolName = '';
+	let owner = '';
+	let customName = '';
 	let description = '';
-	let userIds = [];
 
 	let loading = false;
 
+	let wasShown = false;
+	$: if (show && !wasShown) {
+		resetFields();
+		wasShown = true;
+	} else if (!show) {
+		wasShown = false;
+	}
+
+	const resetFields = () => {
+		category = '';
+		school = '';
+		customSchool = '';
+		department = '';
+		toolType = '';
+		toolName = '';
+		owner = $user?.name ?? '';
+		customName = '';
+		description = '';
+	};
+
+	$: effectiveSchool = school === OTHER_SCHOOL ? customSchool.trim() : school;
+
+	$: generatedName = generateGroupName({
+		category,
+		school: effectiveSchool,
+		department,
+		toolType,
+		toolName,
+		owner
+	});
+
+	$: hasClassification =
+		category !== '' ||
+		effectiveSchool !== '' ||
+		department.trim() !== '' ||
+		toolType !== '' ||
+		toolName.trim() !== '';
+
+	$: displayName =
+		customName.trim() !== '' ? customName.trim() : hasClassification ? generatedName : '';
+
+	$: isDuplicate =
+		displayName !== '' &&
+		existingGroups.some((group) => group?.name?.toLowerCase() === displayName.toLowerCase());
+
 	const submitHandler = async () => {
+		if (customName.trim() === '' && (!category || !effectiveSchool || !toolType)) {
+			toast.error(
+				$i18n.t(
+					'Select a category, school, and tool type to generate a name, or enter a custom group name.'
+				)
+			);
+			return;
+		}
+
 		loading = true;
 
 		const group = {
-			name,
-			description
+			name: displayName,
+			description,
+			meta: {
+				naming: {
+					category,
+					school: effectiveSchool,
+					department: department.trim(),
+					tool_type: toolType,
+					tool_name: toolName.trim(),
+					owner: owner.trim() || ($user?.name ?? ''),
+					custom: customName.trim() !== ''
+				}
+			}
 		};
 
 		await onSubmit(group);
@@ -27,17 +110,11 @@
 		loading = false;
 		show = false;
 
-		name = '';
-		description = '';
-		userIds = [];
+		resetFields();
 	};
-
-	onMount(() => {
-		console.log('mounted');
-	});
 </script>
 
-<Modal size="sm" bind:show>
+<Modal size="md" bind:show>
 	<div>
 		<div class=" flex justify-between dark:text-gray-100 px-5 pt-4 mb-1.5">
 			<div class=" text-lg font-medium self-center font-primary">
@@ -72,23 +149,171 @@
 					}}
 				>
 					<div class="px-1 flex flex-col w-full">
-						<div class="flex gap-2">
+						<div class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+							{$i18n.t('Classification')}
+						</div>
+
+						<div class="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">
 							<div class="flex flex-col w-full">
 								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
-									{$i18n.t('Name')}
+									{$i18n.t('Category')} <span class="text-gray-400 dark:text-gray-600">*</span>
 								</div>
+								<select
+									class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {category ===
+									''
+										? 'text-gray-400 dark:text-gray-500'
+										: ''}"
+									bind:value={category}
+									aria-label={$i18n.t('Category')}
+								>
+									<option value="" disabled>{$i18n.t('Select a category')}</option>
+									{#each CATEGORY_OPTIONS as option}
+										<option value={option.value}>{option.value}</option>
+									{/each}
+								</select>
+							</div>
 
-								<div class="flex-1">
+							<div class="flex flex-col w-full">
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
+									{$i18n.t('School / Unit')}
+									<span class="text-gray-400 dark:text-gray-600">*</span>
+								</div>
+								<select
+									class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {school ===
+									''
+										? 'text-gray-400 dark:text-gray-500'
+										: ''}"
+									bind:value={school}
+									aria-label={$i18n.t('School / Unit')}
+								>
+									<option value="" disabled>{$i18n.t('Select a school or unit')}</option>
+									{#each SCHOOL_OPTIONS as option}
+										<option value={option.value}>{option.value}</option>
+									{/each}
+									<option value={OTHER_SCHOOL}>{$i18n.t('Other (enter below)')}</option>
+								</select>
+								{#if school === OTHER_SCHOOL}
 									<input
-										class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden"
+										class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5 mt-1"
 										type="text"
-										bind:value={name}
-										placeholder={$i18n.t('Group Name')}
+										bind:value={customSchool}
+										placeholder={$i18n.t('School or unit name')}
 										autocomplete="off"
-										required
 									/>
+								{/if}
+							</div>
+
+							<div class="flex flex-col w-full">
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
+									{$i18n.t('Department')}
+								</div>
+								<input
+									class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5"
+									type="text"
+									bind:value={department}
+									placeholder={$i18n.t('e.g. Computer Science (optional)')}
+									autocomplete="off"
+								/>
+							</div>
+
+							<div class="flex flex-col w-full">
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
+									{$i18n.t('Tool Type')} <span class="text-gray-400 dark:text-gray-600">*</span>
+								</div>
+								<select
+									class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {toolType ===
+									''
+										? 'text-gray-400 dark:text-gray-500'
+										: ''}"
+									bind:value={toolType}
+									aria-label={$i18n.t('Tool Type')}
+								>
+									<option value="" disabled>{$i18n.t('Select a tool type')}</option>
+									{#each TOOL_TYPE_OPTIONS as option}
+										<option value={option}>{option}</option>
+									{/each}
+								</select>
+							</div>
+
+							<div class="flex flex-col w-full">
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
+									{$i18n.t('Tool Name')}
+								</div>
+								<input
+									class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5"
+									type="text"
+									bind:value={toolName}
+									placeholder={$i18n.t('e.g. Calculus AI Tutor (optional)')}
+									autocomplete="off"
+								/>
+							</div>
+
+							<div class="flex flex-col w-full">
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
+									{$i18n.t('Group Owner / Admin')}
+									<span class="text-gray-400 dark:text-gray-600">*</span>
+								</div>
+								<input
+									class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5"
+									type="text"
+									bind:value={owner}
+									placeholder={$i18n.t('Owner name')}
+									autocomplete="off"
+								/>
+							</div>
+						</div>
+
+						<hr class="my-3 border-gray-100 dark:border-gray-850" />
+
+						<div class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+							{$i18n.t('Naming')}
+						</div>
+
+						<div class="flex flex-col w-full">
+							<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
+								{$i18n.t('Custom Group Name')}
+							</div>
+							<input
+								class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5"
+								type="text"
+								bind:value={customName}
+								placeholder={$i18n.t('Group Name')}
+								autocomplete="off"
+							/>
+							<div class="mt-0.5 text-xs text-gray-400 dark:text-gray-600">
+								{$i18n.t('Leave empty to use the automatically generated name below.')}
+							</div>
+						</div>
+
+						<div
+							class="mt-2 px-3 py-2 rounded-xl bg-gray-50 dark:bg-gray-850 border border-gray-100 dark:border-gray-800"
+						>
+							<div class="flex items-center justify-between">
+								<div class="text-xs text-gray-500 dark:text-gray-400">
+									{$i18n.t('Group will be created as')}
+								</div>
+								<div
+									class="text-[10px] px-1.5 py-0.5 rounded-full {customName.trim() !== ''
+										? 'bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-200'
+										: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'}"
+								>
+									{customName.trim() !== '' ? $i18n.t('Custom name') : $i18n.t('Auto-generated')}
 								</div>
 							</div>
+							<div class="mt-0.5 text-sm font-medium dark:text-gray-100 min-h-5">
+								{#if displayName !== ''}
+									{displayName}
+								{:else}
+									<span class="text-gray-400 dark:text-gray-600">
+										{$i18n.t('Fill in the fields above to generate a name')}
+									</span>
+								{/if}
+							</div>
+							{#if isDuplicate}
+								<div class="mt-1 text-xs text-amber-600 dark:text-amber-400">
+									{$i18n.t('A group with this name already exists.')}
+								</div>
+							{/if}
 						</div>
 
 						<div class="flex flex-col w-full mt-2">

--- a/src/lib/components/admin/Users/Groups/AddGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/AddGroupModal.svelte
@@ -10,24 +10,31 @@
 	import {
 		CATEGORY_OPTIONS,
 		SCHOOL_OPTIONS,
+		SEMESTER_OPTIONS,
 		TOOL_TYPE_OPTIONS,
-		generateGroupName
+		generateGroupName,
+		yearOptions
 	} from './naming';
 
 	export let onSubmit: Function = () => {};
 	export let show = false;
 	export let existingGroups: { name?: string }[] = [];
 
-	const OTHER_SCHOOL = '__other__';
+	const OTHER = '__other__';
+	const years = yearOptions();
 
 	let category = '';
+	let semester = '';
+	let year = '';
 	let school = '';
 	let customSchool = '';
 	let department = '';
 	let toolType = '';
+	let customToolType = '';
 	let toolName = '';
 	let owner = '';
 	let customName = '';
+	let nameDirty = false;
 	let description = '';
 
 	let loading = false;
@@ -42,47 +49,55 @@
 
 	const resetFields = () => {
 		category = '';
+		semester = '';
+		year = '';
 		school = '';
 		customSchool = '';
 		department = '';
 		toolType = '';
+		customToolType = '';
 		toolName = '';
 		owner = $user?.name ?? '';
 		customName = '';
+		nameDirty = false;
 		description = '';
 	};
 
-	$: effectiveSchool = school === OTHER_SCHOOL ? customSchool.trim() : school;
+	$: effectiveSchool = school === OTHER ? customSchool.trim() : school;
+	$: effectiveToolType = toolType === OTHER ? customToolType.trim() : toolType;
 
 	$: generatedName = generateGroupName({
 		category,
+		semester,
+		year,
 		school: effectiveSchool,
 		department,
-		toolType,
+		toolType: effectiveToolType,
 		toolName,
 		owner
 	});
 
-	$: hasClassification =
-		category !== '' ||
-		effectiveSchool !== '' ||
-		department.trim() !== '' ||
-		toolType !== '' ||
-		toolName.trim() !== '';
+	// The name field is prefilled with the generated name and kept in sync until
+	// the user edits it, so they can tweak from a filled starting point (Reset
+	// restores this link). generatedName does not depend on customName, so this
+	// never loops.
+	$: if (!nameDirty) customName = generatedName;
 
-	$: displayName =
-		customName.trim() !== '' ? customName.trim() : hasClassification ? generatedName : '';
+	$: displayName = customName.trim();
+	$: isCustom = nameDirty && customName.trim() !== generatedName.trim();
 
 	$: isDuplicate =
 		displayName !== '' &&
 		existingGroups.some((group) => group?.name?.toLowerCase() === displayName.toLowerCase());
 
 	const submitHandler = async () => {
-		if (customName.trim() === '' && (!category || !effectiveSchool || !toolType)) {
+		if (semester !== '' && year === '') {
+			toast.error($i18n.t('Select a year for the chosen semester.'));
+			return;
+		}
+		if (displayName === '') {
 			toast.error(
-				$i18n.t(
-					'Select a category, school, and tool type to generate a name, or enter a custom group name.'
-				)
+				$i18n.t('Enter a group name, or fill in the classification fields to generate one.')
 			);
 			return;
 		}
@@ -95,12 +110,14 @@
 			meta: {
 				naming: {
 					category,
+					semester,
+					year,
 					school: effectiveSchool,
 					department: department.trim(),
-					tool_type: toolType,
+					tool_type: effectiveToolType,
 					tool_name: toolName.trim(),
 					owner: owner.trim() || ($user?.name ?? ''),
-					custom: customName.trim() !== ''
+					custom: isCustom
 				}
 			}
 		};
@@ -149,19 +166,19 @@
 					}}
 				>
 					<div class="px-1 flex flex-col w-full">
-						<div class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+						<div class="text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase mb-1.5">
 							{$i18n.t('Classification')}
 						</div>
 
 						<div class="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">
 							<div class="flex flex-col w-full">
-								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
-									{$i18n.t('Category')} <span class="text-gray-400 dark:text-gray-600">*</span>
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">
+									{$i18n.t('Category')} <span class="text-gray-600 dark:text-gray-400">*</span>
 								</div>
 								<select
 									class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {category ===
 									''
-										? 'text-gray-400 dark:text-gray-500'
+										? 'text-gray-500 dark:text-gray-500'
 										: ''}"
 									bind:value={category}
 									aria-label={$i18n.t('Category')}
@@ -174,14 +191,14 @@
 							</div>
 
 							<div class="flex flex-col w-full">
-								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">
 									{$i18n.t('School / Unit')}
-									<span class="text-gray-400 dark:text-gray-600">*</span>
+									<span class="text-gray-600 dark:text-gray-400">*</span>
 								</div>
 								<select
 									class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {school ===
 									''
-										? 'text-gray-400 dark:text-gray-500'
+										? 'text-gray-500 dark:text-gray-500'
 										: ''}"
 									bind:value={school}
 									aria-label={$i18n.t('School / Unit')}
@@ -190,11 +207,11 @@
 									{#each SCHOOL_OPTIONS as option}
 										<option value={option.value}>{option.value}</option>
 									{/each}
-									<option value={OTHER_SCHOOL}>{$i18n.t('Other (enter below)')}</option>
+									<option value={OTHER}>{$i18n.t('Other (enter below)')}</option>
 								</select>
-								{#if school === OTHER_SCHOOL}
+								{#if school === OTHER}
 									<input
-										class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5 mt-1"
+										class="w-full text-sm bg-transparent placeholder:text-gray-500 dark:placeholder:text-gray-500 outline-hidden py-0.5 mt-1"
 										type="text"
 										bind:value={customSchool}
 										placeholder={$i18n.t('School or unit name')}
@@ -204,11 +221,57 @@
 							</div>
 
 							<div class="flex flex-col w-full">
-								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">
+									{$i18n.t('Semester')}
+								</div>
+								<select
+									class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {semester ===
+									''
+										? 'text-gray-500 dark:text-gray-500'
+										: ''}"
+									bind:value={semester}
+									aria-label={$i18n.t('Semester')}
+								>
+									<option value="">{$i18n.t('None')}</option>
+									{#each SEMESTER_OPTIONS as option}
+										<option value={option}>{option}</option>
+									{/each}
+								</select>
+							</div>
+
+							<div class="flex flex-col w-full">
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">
+									{$i18n.t('Year')}
+									{#if semester !== ''}
+										<span class="text-gray-600 dark:text-gray-400">*</span>
+									{/if}
+								</div>
+								<select
+									class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {year ===
+									''
+										? 'text-gray-500 dark:text-gray-500'
+										: ''}"
+									bind:value={year}
+									aria-label={$i18n.t('Year')}
+								>
+									<option value="">{$i18n.t('None')}</option>
+									{#each years as y}
+										<option value={String(y)}>{y}</option>
+									{/each}
+								</select>
+								{#if semester !== '' && year === ''}
+									<div class="mt-0.5 text-xs text-amber-600 dark:text-amber-400">
+										{$i18n.t('Select a year for the chosen semester.')}
+									</div>
+								{/if}
+							</div>
+
+							<div class="flex flex-col w-full">
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">
 									{$i18n.t('Department')}
 								</div>
 								<input
-									class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5"
+									class="w-full text-sm bg-transparent placeholder:text-gray-500 dark:placeholder:text-gray-500 outline-hidden py-0.5"
 									type="text"
 									bind:value={department}
 									placeholder={$i18n.t('e.g. Computer Science (optional)')}
@@ -217,13 +280,13 @@
 							</div>
 
 							<div class="flex flex-col w-full">
-								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
-									{$i18n.t('Tool Type')} <span class="text-gray-400 dark:text-gray-600">*</span>
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">
+									{$i18n.t('Tool Type')} <span class="text-gray-600 dark:text-gray-400">*</span>
 								</div>
 								<select
 									class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {toolType ===
 									''
-										? 'text-gray-400 dark:text-gray-500'
+										? 'text-gray-500 dark:text-gray-500'
 										: ''}"
 									bind:value={toolType}
 									aria-label={$i18n.t('Tool Type')}
@@ -232,15 +295,25 @@
 									{#each TOOL_TYPE_OPTIONS as option}
 										<option value={option}>{option}</option>
 									{/each}
+									<option value={OTHER}>{$i18n.t('Other (enter below)')}</option>
 								</select>
+								{#if toolType === OTHER}
+									<input
+										class="w-full text-sm bg-transparent placeholder:text-gray-500 dark:placeholder:text-gray-500 outline-hidden py-0.5 mt-1"
+										type="text"
+										bind:value={customToolType}
+										placeholder={$i18n.t('Tool type')}
+										autocomplete="off"
+									/>
+								{/if}
 							</div>
 
 							<div class="flex flex-col w-full">
-								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
-									{$i18n.t('Tool Name')}
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">
+									{$i18n.t('Tool Name / Course Name')}
 								</div>
 								<input
-									class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5"
+									class="w-full text-sm bg-transparent placeholder:text-gray-500 dark:placeholder:text-gray-500 outline-hidden py-0.5"
 									type="text"
 									bind:value={toolName}
 									placeholder={$i18n.t('e.g. Calculus AI Tutor (optional)')}
@@ -249,12 +322,12 @@
 							</div>
 
 							<div class="flex flex-col w-full">
-								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">
 									{$i18n.t('Group Owner / Admin')}
-									<span class="text-gray-400 dark:text-gray-600">*</span>
+									<span class="text-gray-600 dark:text-gray-400">*</span>
 								</div>
 								<input
-									class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5"
+									class="w-full text-sm bg-transparent placeholder:text-gray-500 dark:placeholder:text-gray-500 outline-hidden py-0.5"
 									type="text"
 									bind:value={owner}
 									placeholder={$i18n.t('Owner name')}
@@ -265,23 +338,42 @@
 
 						<hr class="my-3 border-gray-100 dark:border-gray-850" />
 
-						<div class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+						<div class="text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase mb-1.5">
 							{$i18n.t('Naming')}
 						</div>
 
 						<div class="flex flex-col w-full">
-							<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
-								{$i18n.t('Custom Group Name')}
+							<div class="mb-0.5 flex items-center justify-between">
+								<div class="text-xs text-gray-600 dark:text-gray-400">
+									{$i18n.t('Group Name')}
+								</div>
+								{#if isCustom}
+									<button
+										type="button"
+										class="text-xs text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:underline transition"
+										on:click={() => {
+											customName = generatedName;
+											nameDirty = false;
+										}}
+									>
+										{$i18n.t('Reset to generated name')}
+									</button>
+								{/if}
 							</div>
 							<input
-								class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5"
+								class="w-full text-sm bg-transparent placeholder:text-gray-500 dark:placeholder:text-gray-500 outline-hidden py-0.5"
 								type="text"
 								bind:value={customName}
+								on:input={() => {
+									nameDirty = true;
+								}}
 								placeholder={$i18n.t('Group Name')}
 								autocomplete="off"
 							/>
-							<div class="mt-0.5 text-xs text-gray-400 dark:text-gray-600">
-								{$i18n.t('Leave empty to use the automatically generated name below.')}
+							<div class="mt-0.5 text-xs text-gray-600 dark:text-gray-400">
+								{$i18n.t(
+									'Prefilled from the classification fields above. Edit for a custom name, or Reset to restore.'
+								)}
 							</div>
 						</div>
 
@@ -289,22 +381,22 @@
 							class="mt-2 px-3 py-2 rounded-xl bg-gray-50 dark:bg-gray-850 border border-gray-100 dark:border-gray-800"
 						>
 							<div class="flex items-center justify-between">
-								<div class="text-xs text-gray-500 dark:text-gray-400">
+								<div class="text-xs text-gray-600 dark:text-gray-400">
 									{$i18n.t('Group will be created as')}
 								</div>
 								<div
-									class="text-[10px] px-1.5 py-0.5 rounded-full {customName.trim() !== ''
+									class="text-[10px] px-1.5 py-0.5 rounded-full {isCustom
 										? 'bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-200'
 										: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'}"
 								>
-									{customName.trim() !== '' ? $i18n.t('Custom name') : $i18n.t('Auto-generated')}
+									{isCustom ? $i18n.t('Custom name') : $i18n.t('Auto-generated')}
 								</div>
 							</div>
 							<div class="mt-0.5 text-sm font-medium dark:text-gray-100 min-h-5">
 								{#if displayName !== ''}
 									{displayName}
 								{:else}
-									<span class="text-gray-400 dark:text-gray-600">
+									<span class="text-gray-600 dark:text-gray-400">
 										{$i18n.t('Fill in the fields above to generate a name')}
 									</span>
 								{/if}
@@ -317,13 +409,13 @@
 						</div>
 
 						<div class="flex flex-col w-full mt-2">
-							<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">
+							<div class=" mb-1 text-xs text-gray-600 dark:text-gray-400">
 								{$i18n.t('Description')}
 							</div>
 
 							<div class="flex-1">
 								<Textarea
-									className="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden resize-none"
+									className="w-full text-sm bg-transparent placeholder:text-gray-500 dark:placeholder:text-gray-500 outline-hidden resize-none"
 									rows={2}
 									bind:value={description}
 									placeholder={$i18n.t('Group Description')}

--- a/src/lib/components/admin/Users/Groups/Display.svelte
+++ b/src/lib/components/admin/Users/Groups/Display.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import Textarea from '$lib/components/common/Textarea.svelte';
-	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import {
+		CATEGORY_OPTIONS,
+		SCHOOL_OPTIONS,
+		TOOL_TYPE_OPTIONS,
+		emptyNaming,
+		generateGroupName
+	} from './naming';
 
 	const i18n = getContext('i18n');
 
@@ -10,12 +16,24 @@
 	export let created_at = '';
 	export let updated_at = '';
 	export let description = '';
+	export let naming = emptyNaming();
 	export let co_admin_emails: string[] | undefined = undefined;
-	if (co_admin_emails !== undefined) {
-		console.log('Display.svelte co_admin_emails:', co_admin_emails);
-	} else {
-		console.log('co_admin_emails MISSING');
-	}
+
+	$: generatedName = generateGroupName({
+		category: naming.category,
+		school: naming.school,
+		department: naming.department,
+		toolType: naming.tool_type,
+		toolName: naming.tool_name,
+		owner: naming.owner
+	});
+
+	// A group can carry a school that is not in the static dropdown list (typed
+	// through the "Other" option at creation), so keep it selectable here.
+	$: schoolChoices =
+		naming.school && !SCHOOL_OPTIONS.some((option) => option.value === naming.school)
+			? [...SCHOOL_OPTIONS, { value: naming.school, abbreviation: naming.school }]
+			: SCHOOL_OPTIONS;
 </script>
 
 <div class="flex gap-2">
@@ -32,28 +50,23 @@
 				required
 			/>
 		</div>
+
+		{#if generatedName !== '' && generatedName !== name}
+			<div class="mt-1 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+				<span>{$i18n.t('Generated name')}: {generatedName}</span>
+				<button
+					class="px-1.5 py-0.5 rounded-full bg-gray-100 hover:bg-gray-200 text-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-400 transition"
+					type="button"
+					on:click={() => {
+						name = generatedName;
+					}}
+				>
+					{$i18n.t('Use')}
+				</button>
+			</div>
+		{/if}
 	</div>
 </div>
-
-<!-- <div class="flex flex-col w-full mt-2">
-	<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Color')}</div>
-
-	<div class="flex-1">
-		<Tooltip content={$i18n.t('Hex Color - Leave empty for default color')} placement="top-start">
-			<div class="flex gap-0.5">
-				<div class="text-gray-500">#</div>
-
-				<input
-					class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden"
-					type="text"
-					bind:value={color}
-					placeholder={$i18n.t('Hex Color')}
-					autocomplete="off"
-				/>
-			</div>
-		</Tooltip>
-	</div>
-</div> -->
 
 <div class="flex flex-col w-full mt-2">
 	<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Description')}</div>
@@ -61,90 +74,149 @@
 	<div class="flex-1">
 		<Textarea
 			className="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden resize-none"
-			rows={4}
+			rows={2}
 			bind:value={description}
 			placeholder={$i18n.t('Group Description')}
 		/>
 	</div>
+</div>
 
+<hr class="my-2 border-gray-100 dark:border-gray-850" />
 
+<div class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+	{$i18n.t('Classification')}
+</div>
 
-	<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Created by')}</div>
+<div class="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">
+	<div class="flex flex-col w-full">
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Category')}</div>
+		<select
+			class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {naming.category ===
+			''
+				? 'text-gray-400 dark:text-gray-500'
+				: ''}"
+			bind:value={naming.category}
+			aria-label={$i18n.t('Category')}
+		>
+			<option value="">{$i18n.t('None')}</option>
+			{#each CATEGORY_OPTIONS as option}
+				<option value={option.value}>{option.value}</option>
+			{/each}
+		</select>
+	</div>
 
-	<div class="flex-1">
-		<Textarea
-			className="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden resize-none"
-			rows={4}
-			bind:value={created_by}
-			placeholder={$i18n.t('Created by')}
+	<div class="flex flex-col w-full">
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('School / Unit')}</div>
+		<select
+			class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {naming.school ===
+			''
+				? 'text-gray-400 dark:text-gray-500'
+				: ''}"
+			bind:value={naming.school}
+			aria-label={$i18n.t('School / Unit')}
+		>
+			<option value="">{$i18n.t('None')}</option>
+			{#each schoolChoices as option}
+				<option value={option.value}>{option.value}</option>
+			{/each}
+		</select>
+	</div>
+
+	<div class="flex flex-col w-full">
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Department')}</div>
+		<input
+			class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5"
+			type="text"
+			bind:value={naming.department}
+			placeholder={$i18n.t('e.g. Computer Science (optional)')}
+			autocomplete="off"
 		/>
 	</div>
 
-		{#if co_admin_emails !== undefined}
-		{#if co_admin_emails.length > 1}
-			<div class=" mb-1 mt-1 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Co-admins')}</div>
-		{:else}
-			<div class=" mb-1 mt-1 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Co-admin')}</div>
-		{/if}
+	<div class="flex flex-col w-full">
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Tool Type')}</div>
+		<select
+			class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {naming.tool_type ===
+			''
+				? 'text-gray-400 dark:text-gray-500'
+				: ''}"
+			bind:value={naming.tool_type}
+			aria-label={$i18n.t('Tool Type')}
+		>
+			<option value="">{$i18n.t('None')}</option>
+			{#each TOOL_TYPE_OPTIONS as option}
+				<option value={option}>{option}</option>
+			{/each}
+		</select>
+	</div>
 
-		<div class="mb-2 flex flex-wrap gap-1 text-xs">
-			{#if co_admin_emails.length > 0}
-				{#each co_admin_emails as email}
-					<div class="flex flex-wrap gap-1 text-xs">
-						{email}
-					</div>
-				{/each}
-			{:else}
-				<div class="text-gray-500 dark:text-gray-600">{$i18n.t('None')}</div>
-			{/if}
+	<div class="flex flex-col w-full">
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Tool Name')}</div>
+		<input
+			class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5"
+			type="text"
+			bind:value={naming.tool_name}
+			placeholder={$i18n.t('e.g. Calculus AI Tutor (optional)')}
+			autocomplete="off"
+		/>
+	</div>
+
+	<div class="flex flex-col w-full">
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
+			{$i18n.t('Group Owner / Admin')}
 		</div>
-	{/if}
-
-	<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Created at')}</div>
-
-	<div class="flex-1">
-		<Textarea
-			className="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden resize-none"
-			rows={4}
-			bind:value={created_at}
-			placeholder={$i18n.t('Created at')}
-		/>
-	</div>
-
-	<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Updated at')}</div>
-
-	<div class="flex-1">
-		<Textarea
-			className="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden resize-none"
-			rows={4}
-			bind:value={updated_at}
-			placeholder={$i18n.t('Updated at')}
+		<input
+			class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5"
+			type="text"
+			bind:value={naming.owner}
+			placeholder={$i18n.t('Owner name')}
+			autocomplete="off"
 		/>
 	</div>
 </div>
 
-<!-- To add new properties:
- 1. Apply here;
- 2. src/lib/components/admin/Users/Groups/EditGroupModal.svelte
- 3. Find <Display bind:name bind:description />
- 4. Bind the new property
- 5. Find src/lib/components/admin/Users/Groups/GroupItem.svelte
- 6. Find bind:show={showEdit}. GroupModal is EditGroupModal.svelte
- 7. They binded users, group, onSubmit, onDelete
- 8. group (in const init) contains the new property
- 9. group has[
-    "id",
-    "user_id",
-    "created_by",
-    "name",
-    "description",
-    "permissions",
-    "data",
-    "meta",
-    "user_ids",
-    "created_at",
-    "updated_at"
-]
-10. in submitHandler, it is going to be handled in "updateGroupById", in src/lib/apis/groups/index.ts (currently no need to add creator name here)
-11. in 
-	 -->
+<hr class="my-2 border-gray-100 dark:border-gray-850" />
+
+<div class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+	{$i18n.t('Details')}
+</div>
+
+<div class="flex flex-col gap-1.5 text-sm">
+	<div class="flex gap-2">
+		<div class="w-24 shrink-0 text-xs text-gray-600 dark:text-gray-500 pt-0.5">
+			{$i18n.t('Created by')}
+		</div>
+		<div class="dark:text-gray-300 break-all">{created_by}</div>
+	</div>
+
+	{#if co_admin_emails !== undefined}
+		<div class="flex gap-2">
+			<div class="w-24 shrink-0 text-xs text-gray-600 dark:text-gray-500 pt-0.5">
+				{co_admin_emails.length > 1 ? $i18n.t('Co-admins') : $i18n.t('Co-admin')}
+			</div>
+			<div class="flex flex-wrap gap-1 dark:text-gray-300">
+				{#if co_admin_emails.length > 0}
+					{#each co_admin_emails as email}
+						<div class="break-all">{email}</div>
+					{/each}
+				{:else}
+					<div class="text-gray-500 dark:text-gray-600">{$i18n.t('None')}</div>
+				{/if}
+			</div>
+		</div>
+	{/if}
+
+	<div class="flex gap-2">
+		<div class="w-24 shrink-0 text-xs text-gray-600 dark:text-gray-500 pt-0.5">
+			{$i18n.t('Created at')}
+		</div>
+		<div class="dark:text-gray-300">{created_at}</div>
+	</div>
+
+	<div class="flex gap-2">
+		<div class="w-24 shrink-0 text-xs text-gray-600 dark:text-gray-500 pt-0.5">
+			{$i18n.t('Updated at')}
+		</div>
+		<div class="dark:text-gray-300">{updated_at}</div>
+	</div>
+</div>

--- a/src/lib/components/admin/Users/Groups/Display.svelte
+++ b/src/lib/components/admin/Users/Groups/Display.svelte
@@ -4,9 +4,11 @@
 	import {
 		CATEGORY_OPTIONS,
 		SCHOOL_OPTIONS,
+		SEMESTER_OPTIONS,
 		TOOL_TYPE_OPTIONS,
 		emptyNaming,
-		generateGroupName
+		generateGroupName,
+		yearOptions
 	} from './naming';
 
 	const i18n = getContext('i18n');
@@ -19,8 +21,12 @@
 	export let naming = emptyNaming();
 	export let co_admin_emails: string[] | undefined = undefined;
 
+	const years = yearOptions();
+
 	$: generatedName = generateGroupName({
 		category: naming.category,
+		semester: naming.semester,
+		year: naming.year,
 		school: naming.school,
 		department: naming.department,
 		toolType: naming.tool_type,
@@ -28,21 +34,30 @@
 		owner: naming.owner
 	});
 
-	// A group can carry a school that is not in the static dropdown list (typed
-	// through the "Other" option at creation), so keep it selectable here.
+	// A group can carry a school, tool type, or year not in the static lists
+	// (typed through "Other" at creation, or a year now out of range), so keep
+	// the stored value selectable here.
 	$: schoolChoices =
 		naming.school && !SCHOOL_OPTIONS.some((option) => option.value === naming.school)
 			? [...SCHOOL_OPTIONS, { value: naming.school, abbreviation: naming.school }]
 			: SCHOOL_OPTIONS;
+	$: toolTypeChoices =
+		naming.tool_type && !TOOL_TYPE_OPTIONS.includes(naming.tool_type)
+			? [...TOOL_TYPE_OPTIONS, naming.tool_type]
+			: TOOL_TYPE_OPTIONS;
+	$: yearChoices =
+		naming.year && !years.some((y) => String(y) === naming.year)
+			? [...years, Number(naming.year)]
+			: years;
 </script>
 
 <div class="flex gap-2">
 	<div class="flex flex-col w-full">
-		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Name')}</div>
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">{$i18n.t('Name')}</div>
 
 		<div class="flex-1">
 			<input
-				class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden"
+				class="w-full text-sm bg-transparent placeholder:text-gray-500 dark:placeholder:text-gray-500 outline-hidden"
 				type="text"
 				bind:value={name}
 				placeholder={$i18n.t('Group Name')}
@@ -52,10 +67,10 @@
 		</div>
 
 		{#if generatedName !== '' && generatedName !== name}
-			<div class="mt-1 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+			<div class="mt-1 flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
 				<span>{$i18n.t('Generated name')}: {generatedName}</span>
 				<button
-					class="px-1.5 py-0.5 rounded-full bg-gray-100 hover:bg-gray-200 text-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-400 transition"
+					class="px-1.5 py-0.5 rounded-full bg-gray-100 hover:bg-gray-200 text-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-300 transition"
 					type="button"
 					on:click={() => {
 						name = generatedName;
@@ -69,11 +84,11 @@
 </div>
 
 <div class="flex flex-col w-full mt-2">
-	<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Description')}</div>
+	<div class=" mb-1 text-xs text-gray-600 dark:text-gray-400">{$i18n.t('Description')}</div>
 
 	<div class="flex-1">
 		<Textarea
-			className="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden resize-none"
+			className="w-full text-sm bg-transparent placeholder:text-gray-500 dark:placeholder:text-gray-500 outline-hidden resize-none"
 			rows={2}
 			bind:value={description}
 			placeholder={$i18n.t('Group Description')}
@@ -83,17 +98,17 @@
 
 <hr class="my-2 border-gray-100 dark:border-gray-850" />
 
-<div class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+<div class="text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase mb-1.5">
 	{$i18n.t('Classification')}
 </div>
 
 <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">
 	<div class="flex flex-col w-full">
-		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Category')}</div>
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">{$i18n.t('Category')}</div>
 		<select
 			class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {naming.category ===
 			''
-				? 'text-gray-400 dark:text-gray-500'
+				? 'text-gray-500 dark:text-gray-500'
 				: ''}"
 			bind:value={naming.category}
 			aria-label={$i18n.t('Category')}
@@ -106,11 +121,11 @@
 	</div>
 
 	<div class="flex flex-col w-full">
-		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('School / Unit')}</div>
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">{$i18n.t('School / Unit')}</div>
 		<select
 			class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {naming.school ===
 			''
-				? 'text-gray-400 dark:text-gray-500'
+				? 'text-gray-500 dark:text-gray-500'
 				: ''}"
 			bind:value={naming.school}
 			aria-label={$i18n.t('School / Unit')}
@@ -123,9 +138,53 @@
 	</div>
 
 	<div class="flex flex-col w-full">
-		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Department')}</div>
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">{$i18n.t('Semester')}</div>
+		<select
+			class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {naming.semester ===
+			''
+				? 'text-gray-500 dark:text-gray-500'
+				: ''}"
+			bind:value={naming.semester}
+			aria-label={$i18n.t('Semester')}
+		>
+			<option value="">{$i18n.t('None')}</option>
+			{#each SEMESTER_OPTIONS as option}
+				<option value={option}>{option}</option>
+			{/each}
+		</select>
+	</div>
+
+	<div class="flex flex-col w-full">
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">
+			{$i18n.t('Year')}
+			{#if naming.semester !== ''}
+				<span class="text-gray-600 dark:text-gray-400">*</span>
+			{/if}
+		</div>
+		<select
+			class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {naming.year ===
+			''
+				? 'text-gray-500 dark:text-gray-500'
+				: ''}"
+			bind:value={naming.year}
+			aria-label={$i18n.t('Year')}
+		>
+			<option value="">{$i18n.t('None')}</option>
+			{#each yearChoices as y}
+				<option value={String(y)}>{y}</option>
+			{/each}
+		</select>
+		{#if naming.semester !== '' && naming.year === ''}
+			<div class="mt-0.5 text-xs text-amber-600 dark:text-amber-400">
+				{$i18n.t('Select a year for the chosen semester.')}
+			</div>
+		{/if}
+	</div>
+
+	<div class="flex flex-col w-full">
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">{$i18n.t('Department')}</div>
 		<input
-			class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5"
+			class="w-full text-sm bg-transparent placeholder:text-gray-500 dark:placeholder:text-gray-500 outline-hidden py-0.5"
 			type="text"
 			bind:value={naming.department}
 			placeholder={$i18n.t('e.g. Computer Science (optional)')}
@@ -134,26 +193,28 @@
 	</div>
 
 	<div class="flex flex-col w-full">
-		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Tool Type')}</div>
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">{$i18n.t('Tool Type')}</div>
 		<select
 			class="w-full text-sm bg-transparent dark:bg-gray-900 outline-hidden py-0.5 {naming.tool_type ===
 			''
-				? 'text-gray-400 dark:text-gray-500'
+				? 'text-gray-500 dark:text-gray-500'
 				: ''}"
 			bind:value={naming.tool_type}
 			aria-label={$i18n.t('Tool Type')}
 		>
 			<option value="">{$i18n.t('None')}</option>
-			{#each TOOL_TYPE_OPTIONS as option}
+			{#each toolTypeChoices as option}
 				<option value={option}>{option}</option>
 			{/each}
 		</select>
 	</div>
 
 	<div class="flex flex-col w-full">
-		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Tool Name')}</div>
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">
+			{$i18n.t('Tool Name / Course Name')}
+		</div>
 		<input
-			class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5"
+			class="w-full text-sm bg-transparent placeholder:text-gray-500 dark:placeholder:text-gray-500 outline-hidden py-0.5"
 			type="text"
 			bind:value={naming.tool_name}
 			placeholder={$i18n.t('e.g. Calculus AI Tutor (optional)')}
@@ -162,11 +223,11 @@
 	</div>
 
 	<div class="flex flex-col w-full">
-		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-400">
 			{$i18n.t('Group Owner / Admin')}
 		</div>
 		<input
-			class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden py-0.5"
+			class="w-full text-sm bg-transparent placeholder:text-gray-500 dark:placeholder:text-gray-500 outline-hidden py-0.5"
 			type="text"
 			bind:value={naming.owner}
 			placeholder={$i18n.t('Owner name')}
@@ -177,13 +238,13 @@
 
 <hr class="my-2 border-gray-100 dark:border-gray-850" />
 
-<div class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+<div class="text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase mb-1.5">
 	{$i18n.t('Details')}
 </div>
 
 <div class="flex flex-col gap-1.5 text-sm">
 	<div class="flex gap-2">
-		<div class="w-24 shrink-0 text-xs text-gray-600 dark:text-gray-500 pt-0.5">
+		<div class="w-24 shrink-0 text-xs text-gray-600 dark:text-gray-400 pt-0.5">
 			{$i18n.t('Created by')}
 		</div>
 		<div class="dark:text-gray-300 break-all">{created_by}</div>
@@ -191,7 +252,7 @@
 
 	{#if co_admin_emails !== undefined}
 		<div class="flex gap-2">
-			<div class="w-24 shrink-0 text-xs text-gray-600 dark:text-gray-500 pt-0.5">
+			<div class="w-24 shrink-0 text-xs text-gray-600 dark:text-gray-400 pt-0.5">
 				{co_admin_emails.length > 1 ? $i18n.t('Co-admins') : $i18n.t('Co-admin')}
 			</div>
 			<div class="flex flex-wrap gap-1 dark:text-gray-300">
@@ -200,21 +261,21 @@
 						<div class="break-all">{email}</div>
 					{/each}
 				{:else}
-					<div class="text-gray-500 dark:text-gray-600">{$i18n.t('None')}</div>
+					<div class="text-gray-600 dark:text-gray-400">{$i18n.t('None')}</div>
 				{/if}
 			</div>
 		</div>
 	{/if}
 
 	<div class="flex gap-2">
-		<div class="w-24 shrink-0 text-xs text-gray-600 dark:text-gray-500 pt-0.5">
+		<div class="w-24 shrink-0 text-xs text-gray-600 dark:text-gray-400 pt-0.5">
 			{$i18n.t('Created at')}
 		</div>
 		<div class="dark:text-gray-300">{created_at}</div>
 	</div>
 
 	<div class="flex gap-2">
-		<div class="w-24 shrink-0 text-xs text-gray-600 dark:text-gray-500 pt-0.5">
+		<div class="w-24 shrink-0 text-xs text-gray-600 dark:text-gray-400 pt-0.5">
 			{$i18n.t('Updated at')}
 		</div>
 		<div class="dark:text-gray-300">{updated_at}</div>

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -13,6 +13,7 @@
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import GarbageBin from '$lib/components/icons/GarbageBin.svelte';
 	import { WEBUI_BASE_URL } from '$lib/constants';
+	import { emptyNaming } from './naming';
 
 	export let onSubmit: Function = () => {};
 	export let onDelete: Function = () => {};
@@ -43,6 +44,8 @@
 
 	export let co_admin_user_ids: string[] = [];
 	export let co_admin_emails: string[] = [];
+
+	let naming = emptyNaming();
 
 
 	export let permissions = {
@@ -83,16 +86,20 @@ $: {
 	const submitHandler = async () => {
 		loading = true;
 
-		const group = {
+		const updatedGroup = {
 			name,
 			description,
 			permissions,
-			user_ids: userIds
+			user_ids: userIds,
+			meta: {
+				...(group?.meta ?? {}),
+				naming
+			}
 
 			// Currently no need to add creator name here
 		};
 
-		await onSubmit(group);
+		await onSubmit(updatedGroup);
 
 		loading = false;
 		show = false;
@@ -227,6 +234,7 @@ $: {
 			name = group.name;
 			description = group.description;
 			permissions = group?.permissions ?? {};
+			naming = { ...emptyNaming(), ...(group?.meta?.naming ?? {}) };
 			created_by = group?.created_by ?? 'Unknown';
 			// user_ids_before_identify = group.user_ids
 			
@@ -401,6 +409,7 @@ $: {
 								<Display
 									bind:name
 									bind:description
+									bind:naming
 									bind:created_by
 									bind:created_at
 									bind:updated_at

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -84,6 +84,11 @@ $: {
 }
 
 	const submitHandler = async () => {
+		if (naming.semester !== '' && naming.year === '') {
+			toast.error($i18n.t('Select a year for the chosen semester.'));
+			return;
+		}
+
 		loading = true;
 
 		const updatedGroup = {

--- a/src/lib/components/admin/Users/Groups/GroupItem.svelte
+++ b/src/lib/components/admin/Users/Groups/GroupItem.svelte
@@ -23,6 +23,7 @@
 	import ConversationHistoryModal from './ConversationHistoryModal.svelte';
 	import EditGroupWorkSpaceModal from './EditGroupWorkSpaceModal.svelte';
 	import { getChatById } from '$lib/apis/chats';
+	import { schoolAbbreviation } from './naming';
 	export let users = [];
 	export let group = {
 		name: 'Admins',
@@ -30,6 +31,8 @@
 	};
 
 	export let setGroups = () => {};
+
+	$: naming = group?.meta?.naming;
 
 	let showEdit = false;
 	let showHistory = false;
@@ -95,11 +98,43 @@
 		showEdit = true;
 	}}
 >
-	<div class="flex items-center gap-1.5 w-288 font-medium text-left">
-		<div>
-			<UserCircleSolid className="size-4" />
+	<div class="flex flex-col gap-0.5 w-288 text-left">
+		<div class="flex items-center gap-1.5 font-medium">
+			<div>
+				<UserCircleSolid className="size-4" />
+			</div>
+			<span>{group.name}</span>
 		</div>
-		{group.name}
+		{#if naming && (naming.category || naming.school || naming.tool_type || naming.tool_name || naming.owner)}
+			<div class="flex flex-wrap items-center gap-1 pl-[1.375rem] text-[10px]">
+				{#if naming.category}
+					<span
+						class="px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+					>
+						{naming.category}
+					</span>
+				{/if}
+				{#if naming.school}
+					<span
+						class="px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+					>
+						{schoolAbbreviation(naming.school)}
+					</span>
+				{/if}
+				{#if naming.tool_name || naming.tool_type}
+					<span
+						class="px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+					>
+						{naming.tool_name || naming.tool_type}
+					</span>
+				{/if}
+				{#if naming.owner}
+					<span class="text-gray-500 dark:text-gray-500 whitespace-nowrap">
+						{$i18n.t('Owner')}: {naming.owner}
+					</span>
+				{/if}
+			</div>
+		{/if}
 	</div>
 
 	<div class="flex items-center gap-1.5 w-76 font-medium text-left">

--- a/src/lib/components/admin/Users/Groups/GroupItem.svelte
+++ b/src/lib/components/admin/Users/Groups/GroupItem.svelte
@@ -93,17 +93,17 @@
 <EditGroupWorkSpaceModal bind:show={showWorkspaceModal}  {group} />
 
 <button
-	class="flex items-center gap-3 justify-between px-1 text-xs w-full transition"
+	class="group flex items-center gap-3 px-1 py-1 rounded-lg text-xs w-full transition hover:bg-gray-50 dark:hover:bg-gray-850"
 	on:click={() => {
 		showEdit = true;
 	}}
 >
-	<div class="flex flex-col gap-0.5 w-288 text-left">
-		<div class="flex items-center gap-1.5 font-medium">
-			<div>
+	<div class="flex flex-col gap-0.5 flex-1 min-w-0 text-left">
+		<div class="flex items-center gap-1.5 font-medium min-w-0">
+			<div class="shrink-0">
 				<UserCircleSolid className="size-4" />
 			</div>
-			<span>{group.name}</span>
+			<span class="truncate group-hover:underline" title={group.name}>{group.name}</span>
 		</div>
 		{#if naming && (naming.category || naming.school || naming.tool_type || naming.tool_name || naming.owner)}
 			<div class="flex flex-wrap items-center gap-1 pl-[1.375rem] text-[10px]">
@@ -129,7 +129,7 @@
 					</span>
 				{/if}
 				{#if naming.owner}
-					<span class="text-gray-500 dark:text-gray-500 whitespace-nowrap">
+					<span class="text-gray-600 dark:text-gray-400 whitespace-nowrap">
 						{$i18n.t('Owner')}: {naming.owner}
 					</span>
 				{/if}
@@ -137,7 +137,7 @@
 		{/if}
 	</div>
 
-	<div class="flex items-center gap-1.5 w-76 font-medium text-left">
+	<div class="flex items-center gap-1.5 w-16 shrink-0 font-medium text-left">
 		{group.user_ids.length}
 
 		<div>
@@ -145,42 +145,42 @@
 		</div>
 	</div>
 
-	<div class="flex items-center gap-1.5 w-136 font-medium text-left">
-		{dayjs(group.created_at * 1000).fromNow()}
-	</div>
-	<div class="flex items-center gap-1.5 w-136 font-medium text-left">
+	<div class="flex items-center gap-1.5 w-24 shrink-0 font-medium text-left">
 		{dayjs(group.last_active_at * 1000).fromNow()}
+	</div>
+	<div class="flex items-center gap-1.5 w-24 shrink-0 font-medium text-left">
+		{dayjs(group.created_at * 1000).fromNow()}
 	</div>
 	<!-- CREATED AT & LAST ACTIVE: src/lib/components/admin/Users/Groups.svelte -->
 	<!-- UserList has similar feature: src/lib/components/admin/Users/UserList.svelte -->
-	<div class="w-full flex w-full items-center gap-1">
+	<div class="w-[320px] shrink-0 flex items-center justify-end gap-1">
 		<button
-			class="rounded-lg p-1 hover:bg-gray-100 dark:hover:bg-gray-850 transition flex items-center gap-1.5"
+			class="rounded-lg p-1 shrink-0 whitespace-nowrap hover:bg-gray-100 dark:hover:bg-gray-850 transition flex items-center gap-1.5"
 			on:click|stopPropagation={() => {
 				showWorkspaceModal = true;
 			}}
 		>
-			<span class="text-xs text-gray-750 dark:text-gray-400 font-medium">Edit Workspace</span>
+			<span class="text-xs text-gray-700 dark:text-gray-400 font-medium">Edit Workspace</span>
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-3.5">
 				<path fill-rule="evenodd" d="M6.955 1.45A.5.5 0 0 1 7.452 1h1.096a.5.5 0 0 1 .497.45l.17 1.699c.484.12.94.312 1.356.562l1.321-1.081a.5.5 0 0 1 .67.033l.774.775a.5.5 0 0 1 .034.67l-1.08 1.32c.25.417.44.873.561 1.357l1.699.17a.5.5 0 0 1 .45.497v1.096a.5.5 0 0 1-.45.497l-1.699.17c-.12.484-.312.94-.562 1.356l1.082 1.322a.5.5 0 0 1-.034.67l-.774.774a.5.5 0 0 1-.67.033l-1.322-1.08c-.416.25-.872.44-1.356.561l-.17 1.699a.5.5 0 0 1-.497.45H7.452a.5.5 0 0 1-.497-.45l-.17-1.699a4.973 4.973 0 0 1-1.356-.562L4.108 13.37a.5.5 0 0 1-.67-.033l-.774-.775a.5.5 0 0 1-.034-.67l1.08-1.32a4.971 4.971 0 0 1-.561-1.357l-1.699-.17A.5.5 0 0 1 1 8.548V7.452a.5.5 0 0 1 .45-.497l1.699-.17c.12-.484.312-.94.562-1.356L2.629 4.107a.5.5 0 0 1 .034-.67l.774-.774a.5.5 0 0 1 .67-.033L5.43 3.71a4.97 4.97 0 0 1 1.356-.561l.17-1.699ZM6 8c0 .538.212 1.026.558 1.385l.057.057a2 2 0 0 0 2.828-2.828l-.058-.056A2 2 0 0 0 6 8Z" clip-rule="evenodd"/>
 			</svg>
 		</button>
 		<!-- History button -->
 		<button
-			class="rounded-lg p-1 hover:bg-gray-100 dark:hover:bg-gray-850 transition flex items-center gap-1.5"
+			class="rounded-lg p-1 shrink-0 whitespace-nowrap hover:bg-gray-100 dark:hover:bg-gray-850 transition flex items-center gap-1.5"
 			on:click|stopPropagation={() => {
 				showHistory = true;
 			}}
 		>
-			<span class="text-xs text-gray-750 dark:text-gray-400 font-medium">Conversation History</span>
+			<span class="text-xs text-gray-700 dark:text-gray-400 font-medium">Conversation History</span>
 			<Clock className="size-3.5" />
 		</button>
 
 		<!-- Existing edit button -->
 		<div
-			class="rounded-lg p-1 hover:bg-gray-100 dark:hover:bg-gray-850 transition flex items-center gap-1.5"
+			class="rounded-lg p-1 shrink-0 whitespace-nowrap hover:bg-gray-100 dark:hover:bg-gray-850 transition flex items-center gap-1.5"
 		>
-			<span class="text-xs text-gray-750 dark:text-gray-400 font-medium whitespace-nowrap">Edit</span>
+			<span class="text-xs text-gray-700 dark:text-gray-400 font-medium whitespace-nowrap">Edit</span>
 			<Pencil className="size-3.5" />
 		</div>
 	</div>

--- a/src/lib/components/admin/Users/Groups/naming.ts
+++ b/src/lib/components/admin/Users/Groups/naming.ts
@@ -1,0 +1,109 @@
+export type GroupNaming = {
+	category: string;
+	school: string;
+	department: string;
+	tool_type: string;
+	tool_name: string;
+	owner: string;
+	custom: boolean;
+};
+
+export type GroupWithNaming = {
+	name?: string;
+	created_by?: string;
+	meta?: { naming?: Partial<GroupNaming> } | null;
+};
+
+export const emptyNaming = (): GroupNaming => ({
+	category: '',
+	school: '',
+	department: '',
+	tool_type: '',
+	tool_name: '',
+	owner: '',
+	custom: false
+});
+
+export const CATEGORY_OPTIONS = [
+	{ value: 'Research', abbreviation: 'R' },
+	{ value: 'Instruction', abbreviation: 'I' },
+	{ value: 'Administration', abbreviation: 'A' }
+];
+
+export const SCHOOL_OPTIONS = [
+	{ value: 'Arts & Science', abbreviation: 'A&S' },
+	{ value: 'College of Dentistry', abbreviation: 'Dentistry' },
+	{ value: 'Grossman School of Medicine', abbreviation: 'Grossman' },
+	{ value: 'NYU IT', abbreviation: 'NYU IT' },
+	{ value: 'Rory Meyers College of Nursing', abbreviation: 'Meyers' },
+	{ value: 'School of Global Public Health', abbreviation: 'GPH' },
+	{ value: 'School of Law', abbreviation: 'Law' },
+	{ value: 'School of Professional Studies (SPS)', abbreviation: 'SPS' },
+	{
+		value: 'Steinhardt School of Culture, Education, and Human Development',
+		abbreviation: 'Steinhardt'
+	},
+	{ value: 'Stern School of Business', abbreviation: 'Stern' },
+	{ value: 'Tandon School of Engineering', abbreviation: 'Tandon' }
+];
+
+export const TOOL_TYPE_OPTIONS = [
+	'AI Tutor',
+	'AI Chatbot',
+	'Research Assistant',
+	'Administrative Assistant',
+	'Data Pipeline',
+	'Knowledge Base Assistant',
+	'Document Assistant',
+	'Analytics Assistant',
+	'Workflow Automation',
+	'Custom Tool'
+];
+
+const abbreviate = (options: { value: string; abbreviation: string }[], value: string) =>
+	options.find((option) => option.value === value)?.abbreviation ?? value;
+
+export const schoolAbbreviation = (school: string) => abbreviate(SCHOOL_OPTIONS, school);
+
+// [Category] - [School] - [Department] - [Tool Name or Tool Type] - [Owner],
+// skipping any part that is empty.
+export const generateGroupName = (fields: {
+	category?: string;
+	school?: string;
+	department?: string;
+	toolType?: string;
+	toolName?: string;
+	owner?: string;
+}): string => {
+	const parts = [
+		fields.category ? abbreviate(CATEGORY_OPTIONS, fields.category) : '',
+		fields.school ? abbreviate(SCHOOL_OPTIONS, fields.school) : '',
+		fields.department?.trim() ?? '',
+		fields.toolName?.trim() || fields.toolType || '',
+		fields.owner?.trim() ?? ''
+	].filter((part) => part !== '');
+
+	return parts.join(' - ');
+};
+
+// Free-text haystack for the group list search: display name plus every piece
+// of structured metadata, so groups stay searchable by category, school,
+// department, tool, and owner even when a custom display name is used.
+export const groupSearchText = (group: GroupWithNaming): string => {
+	const naming = group?.meta?.naming ?? {};
+
+	return [
+		group?.name,
+		naming.category,
+		naming.school,
+		naming.school ? schoolAbbreviation(naming.school) : '',
+		naming.department,
+		naming.tool_type,
+		naming.tool_name,
+		naming.owner,
+		group?.created_by
+	]
+		.filter(Boolean)
+		.join(' ')
+		.toLowerCase();
+};

--- a/src/lib/components/admin/Users/Groups/naming.ts
+++ b/src/lib/components/admin/Users/Groups/naming.ts
@@ -1,5 +1,7 @@
 export type GroupNaming = {
 	category: string;
+	semester: string;
+	year: string;
 	school: string;
 	department: string;
 	tool_type: string;
@@ -16,6 +18,8 @@ export type GroupWithNaming = {
 
 export const emptyNaming = (): GroupNaming => ({
 	category: '',
+	semester: '',
+	year: '',
 	school: '',
 	department: '',
 	tool_type: '',
@@ -33,7 +37,13 @@ export const CATEGORY_OPTIONS = [
 export const SCHOOL_OPTIONS = [
 	{ value: 'Arts & Science', abbreviation: 'A&S' },
 	{ value: 'College of Dentistry', abbreviation: 'Dentistry' },
+	{ value: 'Courant Institute School of Mathematics, Computing, and Data Science', abbreviation: 'Courant' },
+	{ value: 'Gallatin School of Individualized Study', abbreviation: 'Gallatin' },
 	{ value: 'Grossman School of Medicine', abbreviation: 'Grossman' },
+	{ value: 'Institute of Fine Arts', abbreviation: 'IFA' },
+	{ value: 'Institute for the Study of the Ancient World', abbreviation: 'ISAW' },
+	{ value: 'NYU Abu Dhabi', abbreviation: 'NYUAD' },
+	{ value: 'NYU Shanghai', abbreviation: 'NYUSH' },
 	{ value: 'NYU IT', abbreviation: 'NYU IT' },
 	{ value: 'Rory Meyers College of Nursing', abbreviation: 'Meyers' },
 	{ value: 'School of Global Public Health', abbreviation: 'GPH' },
@@ -44,31 +54,44 @@ export const SCHOOL_OPTIONS = [
 		abbreviation: 'Steinhardt'
 	},
 	{ value: 'Stern School of Business', abbreviation: 'Stern' },
-	{ value: 'Tandon School of Engineering', abbreviation: 'Tandon' }
+	{ value: 'Tandon School of Engineering', abbreviation: 'Tandon' },
+	{ value: 'Tisch School of the Arts', abbreviation: 'Tisch' },
 ];
 
-export const TOOL_TYPE_OPTIONS = [
-	'AI Tutor',
-	'AI Chatbot',
-	'Research Assistant',
-	'Administrative Assistant',
-	'Data Pipeline',
-	'Knowledge Base Assistant',
-	'Document Assistant',
-	'Analytics Assistant',
-	'Workflow Automation',
-	'Custom Tool'
-];
+export const TOOL_TYPE_OPTIONS = ['AI Tutor', 'AI Chatbot', 'Data Pipeline'];
+
+export const SEMESTER_OPTIONS = ['Fall', 'Summer', 'Spring'];
+
+// Years span three back through five ahead of the current year (e.g. 2023–2031
+// in 2026), covering historical groups and pre-created future terms.
+export const yearOptions = (): number[] => {
+	const current = new Date().getFullYear();
+	const years: number[] = [];
+	for (let y = current - 3; y <= current + 5; y++) years.push(y);
+	return years;
+};
+
+// A term renders as e.g. FALL2026. Year alone renders as just the year; a
+// semester with no year contributes nothing (the UI requires a year when a
+// semester is chosen).
+export const termToken = (semester?: string, year?: string): string => {
+	if (year && semester) return `${semester.toUpperCase()}${year}`;
+	if (year) return `${year}`;
+	return '';
+};
 
 const abbreviate = (options: { value: string; abbreviation: string }[], value: string) =>
 	options.find((option) => option.value === value)?.abbreviation ?? value;
 
 export const schoolAbbreviation = (school: string) => abbreviate(SCHOOL_OPTIONS, school);
 
-// [Category] - [School] - [Department] - [Tool Name or Tool Type] - [Owner],
-// skipping any part that is empty.
+// [Category] - [Term] - [School] - [Department] - [Tool Type] - [Tool Name] - [Owner],
+// skipping any part that is empty. Tool Type and Tool Name appear side by side
+// rather than one replacing the other.
 export const generateGroupName = (fields: {
 	category?: string;
+	semester?: string;
+	year?: string;
 	school?: string;
 	department?: string;
 	toolType?: string;
@@ -77,9 +100,11 @@ export const generateGroupName = (fields: {
 }): string => {
 	const parts = [
 		fields.category ? abbreviate(CATEGORY_OPTIONS, fields.category) : '',
+		termToken(fields.semester, fields.year),
 		fields.school ? abbreviate(SCHOOL_OPTIONS, fields.school) : '',
 		fields.department?.trim() ?? '',
-		fields.toolName?.trim() || fields.toolType || '',
+		fields.toolType?.trim() ?? '',
+		fields.toolName?.trim() ?? '',
 		fields.owner?.trim() ?? ''
 	].filter((part) => part !== '');
 
@@ -95,6 +120,9 @@ export const groupSearchText = (group: GroupWithNaming): string => {
 	return [
 		group?.name,
 		naming.category,
+		termToken(naming.semester, naming.year),
+		naming.semester,
+		naming.year,
 		naming.school,
 		naming.school ? schoolAbbreviation(naming.school) : '',
 		naming.department,


### PR DESCRIPTION
Implements the Structured Group Naming spec. Group names were previously free
text, so the naming convention had to be enforced by hand outside the system,
and nothing recorded which school, department, or tool a group belonged to or
who owned it.

Group creation now captures structured metadata and generates the name from it,
while still allowing a fully custom display name. The metadata is persisted
either way, so groups stay filterable by category, school, department, tool, and
owner even when the display name is custom.