### PR TITLE
fix: roll back system-default-LLM-function migrations

### DIFF
--- a/backend/open_webui/migrations/versions/817da597db81_bridge_document_chunk_table.py
+++ b/backend/open_webui/migrations/versions/817da597db81_bridge_document_chunk_table.py
@@ -1,0 +1,59 @@
+"""Migration bridge for reverted document_chunk table migration
+
+Revision ID: 817da597db81
+Revises: b2c3d4e5f6a7
+Create Date: 2025-12-03 16:41:09.171266
+
+This is a no-op migration file that exists to handle the case where a
+database was migrated using the original `add_document_chunk_table`
+revision (merged 2025-12-03, reverted 2025-12-04) before that migration
+file was removed from the codebase. Those databases have `alembic_version`
+recorded as this revision id, but no file in the repo can resolve it.
+
+This migration acts as a bridge so Alembic can recognize that database
+state without requiring the original migration file.
+
+IMPORTANT: This migration should NOT be applied if it hasn't already been
+applied. If the database is at an earlier revision, Alembic will try to
+upgrade to this revision, but since this is a no-op, it's safe.
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "817da597db81"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    """
+    No-op upgrade function.
+
+    This migration exists only to bridge the gap for databases that were
+    briefly migrated to the original (later reverted) document_chunk table
+    revision. We don't want to recreate that table here.
+
+    If the database is already at this revision, this function does nothing.
+    If the database is at b2c3d4e5f6a7, this function does nothing (no-op),
+    but Alembic will mark the database as being at this revision.
+    """
+    # No operations needed - this is just a marker migration
+    pass
+
+
+def downgrade():
+    """
+    No-op downgrade function.
+
+    This migration cannot be properly downgraded without the original
+    migration file. However, since this is a no-op, downgrading is also
+    a no-op.
+    """
+    # No operations needed
+    pass

--- a/backend/open_webui/migrations/versions/a393f00ea5c7_drop_function_is_system_default.py
+++ b/backend/open_webui/migrations/versions/a393f00ea5c7_drop_function_is_system_default.py
@@ -5,7 +5,7 @@ reverted). Conditional on the column existing, so it's a no-op anywhere
 the feature never ran.
 
 Revision ID: a393f00ea5c7
-Revises: b2c3d4e5f6a7
+Revises: 817da597db81
 Create Date: 2026-08-18
 
 """
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "a393f00ea5c7"
-down_revision = "b2c3d4e5f6a7"
+down_revision = "817da597db81"
 branch_labels = None
 depends_on = None
 

--- a/backend/open_webui/migrations/versions/a393f00ea5c7_drop_function_is_system_default.py
+++ b/backend/open_webui/migrations/versions/a393f00ea5c7_drop_function_is_system_default.py
@@ -1,0 +1,136 @@
+"""Drop function.is_system_default
+
+Rolls back migrations 019/020 (system-default-LLM-function feature,
+reverted). Conditional on the column existing, so it's a no-op anywhere
+the feature never ran.
+
+Revision ID: a393f00ea5c7
+Revises: b2c3d4e5f6a7
+Create Date: 2026-08-18
+
+"""
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "a393f00ea5c7"
+down_revision = "b2c3d4e5f6a7"
+branch_labels = None
+depends_on = None
+
+_MIGRATEHISTORY_NAMES_TO_CLEAR = (
+    "019_add_function_is_system_default",
+    "020_reassign_system_default_ownership",
+    "020_clear_system_default_portkey_valve",
+)
+
+
+def _column_exists(bind, table_name: str, column_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return column_name in {c["name"] for c in inspector.get_columns(table_name)}
+
+
+def _rename_sole_synthetic_functions(bind) -> None:
+    """If a synthetic system_default_llm row is an admin's only function,
+    rename it to llm_<net_id> instead of deleting it below, so they don't
+    lose their only pipe. Must run before the delete step."""
+    rows = bind.execute(
+        sa.text(
+            "SELECT f.id, f.created_by, f.meta FROM \"function\" f "
+            "WHERE (f.id = 'system_default_llm' OR f.id LIKE 'system\\_default\\_llm\\_\\_%' ESCAPE '\\') "
+            "AND f.is_system_default = TRUE "
+            "AND (SELECT COUNT(*) FROM \"function\" f2 WHERE f2.created_by = f.created_by) = 1"
+        )
+    ).fetchall()
+
+    for old_id, created_by, meta in rows:
+        net_id = (
+            created_by.split("@")[0]
+            if created_by
+            else old_id.replace("system_default_llm__", "").replace("system_default_llm", "")
+        )
+        new_id = f"llm_{net_id}".lower()
+
+        collision = bind.execute(
+            sa.text('SELECT 1 FROM "function" WHERE id = :new_id'),
+            {"new_id": new_id},
+        ).fetchone()
+        if collision:
+            continue
+
+        if isinstance(meta, str):
+            try:
+                meta = json.loads(meta)
+            except (TypeError, ValueError):
+                meta = {}
+        if not isinstance(meta, dict):
+            meta = {}
+        meta["description"] = "llm"
+
+        bind.execute(
+            sa.text(
+                'UPDATE "function" SET id = :new_id, name = :new_name, meta = :new_meta '
+                "WHERE id = :old_id"
+            ),
+            {"new_id": new_id, "new_name": "llm", "new_meta": json.dumps(meta), "old_id": old_id},
+        )
+
+
+def _reset_adoption_flags(bind) -> None:
+    """Clear function.default_adoption_done in every config row that has it set."""
+    rows = bind.execute(sa.text('SELECT id, data FROM "config"')).fetchall()
+
+    for row_id, data in rows:
+        if isinstance(data, str):
+            try:
+                data = json.loads(data)
+            except (TypeError, ValueError):
+                continue
+        if not isinstance(data, dict):
+            continue
+
+        function_cfg = data.get("function")
+        if not isinstance(function_cfg, dict) or not function_cfg.get("default_adoption_done"):
+            continue
+
+        function_cfg["default_adoption_done"] = False
+        bind.execute(
+            sa.text('UPDATE "config" SET data = :data WHERE id = :id'),
+            {"data": json.dumps(data), "id": row_id},
+        )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    if _column_exists(bind, "function", "is_system_default"):
+        _rename_sole_synthetic_functions(bind)
+
+        # is_system_default in the WHERE clause guards against a real
+        # function that happens to share the id pattern.
+        op.execute(
+            sa.text(
+                "DELETE FROM \"function\" WHERE "
+                "(id = 'system_default_llm' OR id LIKE 'system\\_default\\_llm\\_\\_%' ESCAPE '\\') "
+                "AND is_system_default = TRUE"
+            )
+        )
+
+        op.drop_column("function", "is_system_default")
+        _reset_adoption_flags(bind)
+
+    op.execute(
+        sa.text(
+            "DELETE FROM migratehistory WHERE name IN "
+            "('019_add_function_is_system_default', "
+            "'020_reassign_system_default_ownership', "
+            "'020_clear_system_default_portkey_valve')"
+        )
+    )
+
+
+def downgrade() -> None:
+    """No-op: nothing here is reconstructable."""
+    pass


### PR DESCRIPTION
# Changelog Entry

### Description

Rolls back a system-default-LLM-function feature that shipped two migrations to dev and was later reverted from the code without reverting what those migrations had already done to the database. The leftover `is_system_default` column and synthetic function rows had broken function creation for every admin on dev, not only the ones the feature had touched.

### Changed

- Admins whose only function was one of the feature's synthetic rows have it renamed to match the app's own naming convention, instead of deleted, so they aren't left with zero functions.

### Removed

- The `is_system_default` column on `function`.
- Duplicate synthetic `system_default_llm` / `system_default_llm__<net_id>` rows, for admins who also have a real function of their own.

### Fixed

- Function creation, broken for every admin on dev by the leftover column.
- A separate, pre-existing issue found while deploying this fix: dev's Alembic bookkeeping was stuck on an orphaned revision from an unrelated December 2025 incident, which blocked this migration from running. A no-op bridge revision resolves the chain.

---

### Additional Information

- Both migrations were tested against a full reproduction of the real deploy history, then verified directly against the real dev database after deploy: schema clean, no leftover duplicate functions, function creation confirmed working.
- The original feature's branch is not part of this PR and is being abandoned separately.